### PR TITLE
Early return when thousandSeparator is blank

### DIFF
--- a/src/bootstrap-input-spinner.js
+++ b/src/bootstrap-input-spinner.js
@@ -248,13 +248,28 @@
                 }
             }
 
-            function parseLocaleNumber(stringNumber) {
+            function removeThousandSeparators(stringNumber) {
                 var numberFormat = new Intl.NumberFormat(locale)
                 var thousandSeparator = numberFormat.format(1111).replace(/1/g, '')
-                var decimalSeparator = numberFormat.format(1.1).replace(/1/g, '')
-                return parseFloat(stringNumber
+                if (!thousandSeparator) return stringNumber
+                return stringNumber
                     .replace(new RegExp('\\' + thousandSeparator, 'g'), '')
+            }
+
+            function unifyDecimalSeparator(stringNumber) {
+                var numberFormat = new Intl.NumberFormat(locale)
+                var decimalSeparator = numberFormat.format(1.1).replace(/1/g, '')
+                return stringNumber
                     .replace(new RegExp('\\' + decimalSeparator), '.')
+            }
+
+            function parseLocaleNumber(stringNumber) {
+                return parseFloat(
+                    removeThousandSeparators(
+                        unifyDecimalSeparator(
+                            stringNumber
+                        )
+                    )
                 )
             }
         })

--- a/src/bootstrap-input-spinner.js
+++ b/src/bootstrap-input-spinner.js
@@ -251,7 +251,9 @@
             function removeThousandSeparators(stringNumber) {
                 var numberFormat = new Intl.NumberFormat(locale)
                 var thousandSeparator = numberFormat.format(1111).replace(/1/g, '')
-                if (!thousandSeparator) return stringNumber
+                // early exit to avoid SyntaxError on blank
+                if (thousandSeparator === '') return stringNumber
+
                 return stringNumber
                     .replace(new RegExp('\\' + thousandSeparator, 'g'), '')
             }


### PR DESCRIPTION
_bootstrap-input-spinner.js:256 Uncaught SyntaxError: Invalid regular expression: /\/: \ at end of pattern
    at new RegExp (<anonymous>)
    at parseLocaleNumber (_bootstrap-input-spinner.js:256)
    at HTMLInputElement.<anonymous> (_bootstrap-input-spinner.js:112)
    at HTMLInputElement.dispatch (jquery.min.js:2)
    at HTMLInputElement.v.handle (jquery.min.js:2)
    at Object.trigger (jquery.min.js:2)
    at Object.simulate (jquery.min.js:2)
    at HTMLDocument.i (jquery.min.js:2)