### PR TITLE
Update bootstrap-input-spinner.js

### DIFF
--- a/src/bootstrap-input-spinner.js
+++ b/src/bootstrap-input-spinner.js
@@ -268,7 +268,7 @@
 
             function parseLocaleNumber(stringNumber) {
                 var numberFormat = new Intl.NumberFormat(locale)
-                var thousandSeparator = numberFormat.format(1111).replace(/1/g, '') || '.'
+                var thousandSeparator = numberFormat.format(11111).replace(/1/g, '') || '.'
                 var decimalSeparator = numberFormat.format(1.1).replace(/1/g, '')
                 return parseFloat(stringNumber
                     .replace(new RegExp(' ', 'g'), '')


### PR DESCRIPTION
```
(new Intl.NumberFormat("et-EE")).format(1111)
"1111"
```

vs

```
(new Intl.NumberFormat("et-EE")).format(11111)
"11 111"
```