### PR TITLE
Bootstrap 5 upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # bootstrap-input-spinner
 
-A Bootstrap 4 / jQuery plugin to create input spinner elements for number input.
+A Bootstrap 5 / jQuery plugin to create input spinner elements for number input.
 
 **[Demo page with examples](http://shaack.com/projekte/bootstrap-input-spinner/)**
 
@@ -9,7 +9,7 @@ A Bootstrap 4 / jQuery plugin to create input spinner elements for number input.
 
 ## Features
 
-The Bootstrap 4 InputSpinner
+The Bootstrap 5 InputSpinner
 
 - is **mobile friendly** and **responsive**,
 - automatically changes the value when **holding a button**,
@@ -19,7 +19,7 @@ The Bootstrap 4 InputSpinner
 - **dynamically handles** changing **attribute values** like `disabled` or `class`,
 - supports **templates** and **custom editors**, (*new!*)
 - dispatches **`change`** and **`input`** **events on value change** like the native element and
-- works **without extra css**, only bootstrap 4 is needed.
+- works **without extra css**, only bootstrap 5 is needed.
 
 ## Quickstart
 
@@ -51,7 +51,7 @@ It is a jQuery plugin. So, enable the InputSpinner for all inputs with `type='nu
 </script>
 ```
 
-Thats it. **No extra css needed**, just Bootstrap 4 and jQuery.
+Thats it. **No extra css needed**, just Bootstrap 5 and jQuery.
 
 ## API Reference
 
@@ -104,9 +104,9 @@ var props = {
     editor: I18nEditor, // the editor (parsing and rendering of the input)
     template: // the template of the input
         '<div class="input-group ${groupClass}">' +
-        '<div class="input-group-prepend"><button style="min-width: ${buttonsWidth}" class="btn btn-decrement ${buttonsClass} btn-minus" type="button">${decrementButton}</button></div>' +
+        '<button style="min-width: ${buttonsWidth}" class="btn btn-decrement ${buttonsClass} btn-minus" type="button">${decrementButton}</button>' +
         '<input type="text" inputmode="decimal" style="text-align: ${textAlign}" class="form-control form-control-text-input"/>' +
-        '<div class="input-group-append"><button style="min-width: ${buttonsWidth}" class="btn btn-increment ${buttonsClass} btn-plus" type="button">${incrementButton}</button></div>' +
+        '<button style="min-width: ${buttonsWidth}" class="btn btn-increment ${buttonsClass} btn-plus" type="button">${incrementButton}</button>' +
         '</div>'
 }
 ```

--- a/index.html
+++ b/index.html
@@ -31,14 +31,14 @@
 <section class="container py-5">
     <h1>bootstrap-input-spinner</h1>
     <p>
-        A Bootstrap 4 / jQuery plugin to create input spinner elements for number input, by
+        A Bootstrap 5 / jQuery plugin to create input spinner elements for number input, by
         <a href="https://shaack.com/en">shaack.com</a> engineering.
     </p>
     <p>
         License: <a href="https://github.com/shaack/bootstrap-input-spinner/blob/master/LICENSE">MIT</a>
     </p>
     <h2>Features</h2>
-    <p>The Bootstrap 4 InputSpinner</p>
+    <p>The Bootstrap 5 InputSpinner</p>
     <ul>
         <li>
             is <b>mobile friendly</b> and <b>responsive</b>,
@@ -64,13 +64,13 @@
             change</b> like the native element,
         </li>
         <li>
-            <b>needs no extra css</b>, just Bootstrap 4.
+            <b>needs no extra css</b>, just Bootstrap 5.
         </li>
     </ul>
     <h2>Usage</h2>
     <p>
         This script enables the InputSpinner for all inputs with <code>type='number'</code>.
-        <b>No extra css needed</b>, just Bootstrap 4.
+        <b>No extra css needed</b>, just Bootstrap 5.
     </p>
     <pre><code class="language-html">&lt;script src="./src/bootstrap-input-spinner.js">&lt;/script>
 &lt;script>
@@ -418,21 +418,17 @@ $inputLoop.on("change", function (event) {
         $("#templateButtonsRight").inputSpinner({
             template:
                 '<div class="input-group ${groupClass}">' +
-                '<div class="input-group-prepend"></div>' +
                 '<input type="text" inputmode="decimal" style="text-align: ${textAlign}" class="form-control"/>' +
-                '<div class="input-group-append">' +
                 '<button style="min-width: ${buttonsWidth}" class="btn btn-decrement ${buttonsClass}" type="button">${decrementButton}</button>' +
                 '<button style="min-width: ${buttonsWidth}" class="btn btn-increment ${buttonsClass}" type="button">${incrementButton}</button>' +
-                '</div></div>'
+                '</div>'
         })
     </script>
     <pre><code class="language-html">&lt;div class="input-group ${groupClass}">
-&lt;div class="input-group-prepend">&lt;/div>
 &lt;input type="text" inputmode="decimal" style="text-align: ${textAlign}" class="form-control"/>
-&lt;div class="input-group-append">
 &lt;button style="min-width: ${buttonsWidth}" class="btn btn-decrement ${buttonsClass}" type="button">${decrementButton}&lt;/button>
 &lt;button style="min-width: ${buttonsWidth}" class="btn btn-increment ${buttonsClass}" type="button">${incrementButton}&lt;/button>
-&lt;/div>&lt;/div></code></pre>
+&lt;/div></code></pre>
     <p>You can... or must use the following variables in your template:</p>
     <ul>
         <li>${groupClass}</li>
@@ -473,8 +469,8 @@ $inputLoop.on("change", function (event) {
     <div class="card my-5 border-info">
         <a href="https://shaack.com/en/open-source-components">
             <div class="card-body">
-                <h4 class="mb-2">More Bootstrap 4 components (from shaack.com)</h4>
-                You may want to check out our further Bootstrap 4 extensions,
+                <h4 class="mb-2">More Bootstrap 5 components (from shaack.com)</h4>
+                You may want to check out our further Bootstrap 5 extensions,
                 <b>bootstrap-show-modal</b> and
                 <b>bootstrap-detect-breakpoint</b>.
             </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "bootstrap-input-spinner",
-  "version": "2.1.2",
+  "version": "3.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "2.1.2",
+      "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
         "bootstrap": "^4.6.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bootstrap-input-spinner",
-  "version": "2.1.2",
-  "description": "A Bootstrap 4 / jQuery plugin to create input spinner elements for number input.",
+  "version": "3.0.0",
+  "description": "A Bootstrap 5 / jQuery plugin to create input spinner elements for number input.",
   "browser": "./src/bootstrap-input-spinner.js",
   "scripts": {
     "test": "tput setaf 4;echo open test/index.html in your browser for testing."
@@ -11,7 +11,7 @@
     "url": "git+https://github.com/shaack/bootstrap-input-spinner.git"
   },
   "keywords": [
-    "Bootstrap 4",
+    "Bootstrap 5",
     "Bootstrap",
     "jQuery",
     "Widget",

--- a/src/bootstrap-input-spinner.js
+++ b/src/bootstrap-input-spinner.js
@@ -75,9 +75,9 @@
             editor: I18nEditor, // the editor (parsing and rendering of the input)
             template: // the template of the input
                 '<div class="input-group ${groupClass}">' +
-                '<div class="input-group-prepend"><button style="min-width: ${buttonsWidth}" class="btn btn-decrement ${buttonsClass} btn-minus" type="button">${decrementButton}</button></div>' +
+                '<button style="min-width: ${buttonsWidth}" class="btn btn-decrement ${buttonsClass} btn-minus" type="button">${decrementButton}</button>' +
                 '<input type="text" inputmode="decimal" style="text-align: ${textAlign}" class="form-control form-control-text-input"/>' +
-                '<div class="input-group-append"><button style="min-width: ${buttonsWidth}" class="btn btn-increment ${buttonsClass} btn-plus" type="button">${incrementButton}</button></div>' +
+                '<button style="min-width: ${buttonsWidth}" class="btn btn-increment ${buttonsClass} btn-plus" type="button">${incrementButton}</button>' +
                 '</div>'
         }
 
@@ -130,11 +130,11 @@
 
                 if (prefix) {
                     var prefixElement = $('<span class="input-group-text">' + prefix + '</span>')
-                    $inputGroup.find(".input-group-prepend").append(prefixElement)
+                    $inputGroup.find("input").before(prefixElement)
                 }
                 if (suffix) {
                     var suffixElement = $('<span class="input-group-text">' + suffix + '</span>')
-                    $inputGroup.find(".input-group-append").prepend(suffixElement)
+                    $inputGroup.find("input").after(suffixElement)
                 }
 
                 $original[0].setValue = function (newValue) {


### PR DESCRIPTION
> Dropped .input-group-append and .input-group-prepend. You can now just add buttons and .input-group-text as direct children of the input groups.
[https://getbootstrap.com/docs/5.0/migration/](https://getbootstrap.com/docs/5.0/migration/)

bootstrap-input-spinner's styling was broken.
Fix was simply to:

- get rid of .input-group-append and .input-group-prepend
- change the way prefix and suffix are appended/prepended to the input

Docs have and examples have also been updated to reflect the change.

I also bumped the version to 3.0.0 as could have 2.x for bootstrap 4 support & 3.x for bootstrap 5 support