### PR TITLE
Fix: #114 Lighthouse warning 'Does not use passive listeners to improve scrolling performance".

### DIFF
--- a/src/bootstrap-input-spinner.js
+++ b/src/bootstrap-input-spinner.js
@@ -192,7 +192,11 @@
                         stepHandling(step)
                     }
                 })
-                onPointerUp(document.body, function () {
+                onPointerUp($buttonDecrement[0], function () {
+                    resetTimer()
+                    dispatchEvent($original, "change")
+                })
+                onPointerUp($buttonIncrement[0], function () {
                     resetTimer()
                     dispatchEvent($original, "change")
                 })

--- a/src/bootstrap-input-spinner.js
+++ b/src/bootstrap-input-spinner.js
@@ -349,7 +349,7 @@
                 e.preventDefault()
             }
             callback(e)
-        }, {passive: true})
+        }, {passive: false})
         element.addEventListener("keydown", function (e) {
             if ((e.keyCode === 32 || e.keyCode === 13) && !triggerKeyPressed) {
                 triggerKeyPressed = true

--- a/src/bootstrap-input-spinner.js
+++ b/src/bootstrap-input-spinner.js
@@ -328,7 +328,7 @@
         })
         element.addEventListener("touchend", function (e) {
             callback(e)
-        })
+        }, {passive: true})
         element.addEventListener("keyup", function (e) {
             if ((e.keyCode === 32 || e.keyCode === 13)) {
                 triggerKeyPressed = false
@@ -349,7 +349,7 @@
                 e.preventDefault()
             }
             callback(e)
-        })
+        }, {passive: true})
         element.addEventListener("keydown", function (e) {
             if ((e.keyCode === 32 || e.keyCode === 13) && !triggerKeyPressed) {
                 triggerKeyPressed = true


### PR DESCRIPTION
Adding passive argument to touch events fixes the issue, as stated in the [Google Chrome dev documentation](https://developer.chrome.com/docs/lighthouse/best-practices/uses-passive-event-listeners/) :)